### PR TITLE
support download auto_log.h from third-party url

### DIFF
--- a/deploy/cpp_infer/CMakeLists.txt
+++ b/deploy/cpp_infer/CMakeLists.txt
@@ -206,6 +206,10 @@ endif()
 
 set(DEPS ${DEPS} ${OpenCV_LIBS})
 
+include(ExternalProject)
+include(external-cmake/auto-log.cmake)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/autolog/src/extern_Autolog/auto_log)
+
 AUX_SOURCE_DIRECTORY(./src SRCS)
 add_executable(${DEMO_NAME} ${SRCS})
 

--- a/deploy/cpp_infer/external-cmake/auto-log.cmake
+++ b/deploy/cpp_infer/external-cmake/auto-log.cmake
@@ -1,0 +1,14 @@
+find_package(Git REQUIRED)
+message("${CMAKE_BUILD_TYPE}")
+
+set(AUTOLOG_REPOSITORY     https://github.com/LDOUBLEV/AutoLog.git)
+SET(AUTOLOG_INSTALL_DIR   ${CMAKE_CURRENT_BINARY_DIR}/install/Autolog)
+
+ExternalProject_Add(
+    extern_Autolog
+    PREFIX autolog
+    GIT_REPOSITORY ${AUTOLOG_REPOSITORY}
+    GIT_TAG support_cpp_log
+    DOWNLOAD_NO_EXTRACT True
+    INSTALL_COMMAND cmake -E echo "Skipping install step."
+)

--- a/deploy/cpp_infer/external-cmake/auto-log.cmake
+++ b/deploy/cpp_infer/external-cmake/auto-log.cmake
@@ -8,7 +8,7 @@ ExternalProject_Add(
     extern_Autolog
     PREFIX autolog
     GIT_REPOSITORY ${AUTOLOG_REPOSITORY}
-    GIT_TAG support_cpp_log
+    GIT_TAG main
     DOWNLOAD_NO_EXTRACT True
     INSTALL_COMMAND cmake -E echo "Skipping install step."
 )


### PR DESCRIPTION
1. download `auto_log` from https://github.com/LDOUBLEV/AutoLog.git and disable compile